### PR TITLE
Fix spacing issues between lists, closes #12

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,45 +1,38 @@
 # Table of Contents
 1. [Table of Contents](SUMMARY.md)
 2. [Tutorial: Install and Initialize IPFS](/install-ipfs/README.md)
-
   1. [Lesson: Download and Install IPFS](/install-ipfs/lessons/download-and-install.md)
   2. [Lesson: Initialize your IPFS Repository](/install-ipfs/lessons/initialize-repository.md)
 
 2. [Tutorial: Files on IPFS](files-on-ipfs/README.md)
-
   1. [Lesson: Add Content to IPFS and Retrieve It](/files-on-ipfs/lessons/add-and-retrieve-file-content.md)
   2. [Lesson: Wrap Filenames and Directory Info around Content](/files-on-ipfs/lessons/wrap-directories-around-content.md)
   3. [Lesson: Pinning - Tell IPFS to Keep a File](/files-on-ipfs/lessons/pin-files.md)
 
 3. [Tutorial: Going Online - Joining the Distributed Web](/going-online/README.md)
-
   1. Lesson: Publish your node on the IPFS network
   2. Lesson: Find Peers on the Network
   3. Lession: Retrieve content from a Peer
   4. Lesson: Streaming Video over IPFS
 
 4. [Tutorial: Interacting with the Classical (HTTP) Web](/classical-web/README.md)
-
   1. Lesson: Use an HTTP browser to retrieve files from local IPFS node
   2. Lesson: Get your own files through the ipfs.io gateway
   3. Lesson: Map DNS to IPNS
 
 5. [Tutorial: Publishing Changes on the Permanent Web](publishing-changes/README.md)
-
   1. Lesson: Set up IPNS on your IPFS Node
   2. Lesson: Create an IPNS entry that points to your file
   3. Lesson: Modify your File and add the modified version to IPFS
   4. Lesson: Update the IPNS entry to point to the new version
 
 6. [Tutorial: Merkle Trees and the IPFS DAG](ipfs-dag/README.md)
-
   1. [Lesson: Turn a file into a tree of hashes](/ipfs-dag/lessons/files-as-dags.md)
   2. Lesson: Create a cryptographic hash
   3. [Lesson: Build a tree of data in IPFS using cryptographic hashes to link the pieces (a Merkle DAG)](/ipfs-dag/lessons/blocks-from-scratch.md)
   4. Lesson: Explore the types of software that use hash trees to track data
 
 7. [Tutorial: Dynamic Content on IPFS](/dynamic-content/README.md)
-
   1. Disclaimer: Dynamic content on IPFS is a Work in Progress
   2. Lesson: Add data to the DAG (locally)
   3. Lesson: Tell peers about your Changes


### PR DESCRIPTION
With the line break in between the parent list, Markdown believes it's a new list instead of belonging to the previous one.